### PR TITLE
Link absent nodes

### DIFF
--- a/lib/arch.js
+++ b/lib/arch.js
@@ -19,8 +19,7 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
         this.nodes = {};
         this.parents = {};
         this.children = {};
-        this.lazyParents = {};
-        this.lazyChildren = {};
+        this.lazyLinks = {}
         this.plans = {};
         this.locked = 0;
     },
@@ -142,27 +141,22 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
         return this;
     },
 
+    /**
+     * Attempts to establish lazy links of the specified node as real
+     * @param {Object|String} node Node to apply links for
+     */
     applyLazyLinks: function(node) {
         var id = U.getNodeId(node);
 
-        if (this.lazyChildren[id]) {
-            var parents = this.lazyChildren[id];
+        if (this.lazyLinks[id]) {
+            var links = this.lazyLinks[id];
 
-            parents.forEach(function(p) {
-                if (this.hasNode(U.getNodeId(p.parent))) {
-                    this.link(p.child, p.parent);
-                    p.ref++;
-                }
-            }, this);
-        }
-
-        if (this.lazyParents[id]) {
-            var children = this.lazyParents[id];
-
-            children.forEach(function(c) {
-                if (this.hasNode(U.getNodeId(c.child))) {
-                    this.link(c.child, c.parent);
-                    c.ref++;
+            links.forEach(function(l) {
+                if (this.hasNode(U.getNodeId(l.parent)) && this.hasNode(U.getNodeId(l.child)) &&
+                    !this.hasParents(l.child, l.parent))
+                {
+                    this.link(l.child, l.parent);
+                    l.ref++;
                 }
             }, this);
         }
@@ -302,40 +296,31 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
      *
      * @param {String|Object} id Node (ID or node object).
      * @param {String[]|String} children Children nodes IDs.
+     * @param {Boolean} [lazy] pass true to add lazy links
      * @return {Arch}
      */
     addChildren: function(id, children, lazy) {
         var parent = U.getNodeId(id);
         children = U.toArray(children);
 
-        if (lazy) {
-            var childrenList = this.lazyParents[parent] = this.lazyParents[parent] || [];
-
-            children.forEach(function(c) {
-                var link = {
-                        parent: parent,
-                        child: U.getNodeId(c),
-                        ref: 0
-                    };
-
-
-                if (!this._lazyLinkExist(parent, link.child)) {
-                    childrenList.push(link);
-                    (this.lazyChildren[link.child] = this.lazyChildren[link.child] || []).push(link);
-                }
-            }, this);
-
-        }
         return this.link(children, parent, lazy);
     },
 
+    /**
+     * Returns true if lazy link between parent and child exists false otherwise
+     * @param {String|Object} parent
+     * @param {String|Object} child
+     * @return {Boolean}
+     * @private
+     */
     _lazyLinkExist: function(parent, child) {
-        var children = this.lazyParents[parent];
+        var links = this.lazyLinks[U.getNodeId(parent)];
 
-        if (!children) return false;
+        if (!links) return false;
 
-        for(var i = 0; i < children.length; i++) {
-            if (children[i].child === child) return true;
+        for(var i = 0; i < links.length; i++) {
+            var link = links[i];
+            if (link.parent === parent && link.child === child) return true;
         }
 
         return false;
@@ -346,29 +331,13 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
      *
      * @param {String|Object} id Node (ID or node object).
      * @param {String[]|String} parents Parents nodes IDs.
+     * @param {Boolean} [lazy] pass true to add links as lazy
      * @return {Arch}
      */
     addParents: function(id, parents, lazy) {
         var child = U.getNodeId(id);
         parents = U.toArray(parents);
 
-        if (lazy) {
-            var parentsList = this.lazyChildren[child] = this.lazyChildren[child] || [];
-
-            parents.forEach(function(p) {
-                var link = {
-                    parent: U.getNodeId(p),
-                    child: child,
-                    ref: 0
-                };
-
-                if (!this._lazyLinkExist(link.parent, child)) {
-                    parentsList.push(link);
-                    (this.lazyParents[link.parent] = this.lazyParents[link.parent] || []).push(link);
-                }
-            }, this);
-
-        }
         return this.link(child, parents, lazy);
     },
 
@@ -377,6 +346,7 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
      *
      * @param {String[]|String} children IDs of child nodes.
      * @param {String[]|String} parents IDs of parent nodes.
+     * @param {Boolean} [lazy] pass true to add links as lazy
      * @returns {Arch} Chainable API.
      */
     link: function(children, parents, lazy) {
@@ -398,11 +368,10 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
      *
      * @param {String} child Child node ID.
      * @param {Array} parents Parent nodes IDs.
+     * @param {Boolean} [lazy] pass true to add links as lazy
      */
     _link: function(child, parents, lazy) {
         child = U.getNodeId(child);
-
-        if (lazy && !this.hasNode(child)) return;
 
         var _parents = this.parents[child],
             children;
@@ -410,9 +379,22 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
         parents.forEach(function(parent) {
             parent = U.getNodeId(parent);
 
-            if (this.hasParents(child, parent)) return;
+            if (lazy) {
+                var link = {
+                    parent: parent,
+                    child: child,
+                    ref: 0
+                };
 
-            if (lazy && !this.hasNode(parent)) return;
+                if (!this._lazyLinkExist(parent, child)) {
+                    (this.lazyLinks[child] = this.lazyLinks[child] || []).push(link);
+                    (this.lazyLinks[parent] = this.lazyLinks[parent] || []).push(link);
+                }
+
+                if (!this.hasNode(parent) || !this.hasNode(child)) return;
+            }
+
+            if (this.hasParents(child, parent)) return;
 
             children = this.children[parent] || (this.children[parent] = []);
 
@@ -436,6 +418,10 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
     unlink: function(id1, id2) {
         ASSERTS.idTypeIsString(id1);
         ASSERTS.idTypeIsString(id2);
+
+        this.unlinkLazy(id1, id2);
+        this.unlinkLazy(id2, id1);
+
         ASSERTS.hasId(id1, this);
         ASSERTS.hasId(id2, this);
 
@@ -448,6 +434,23 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
         }
 
         return this;
+    },
+
+    unlinkLazy: function(id1, id2) {
+        var links = this.lazyLinks[id1];
+        if (links) {
+            for(var i = links.length - 1; i >= 0; i--) {
+                var link = links[i];
+
+                if ((link.parent === id1 && link.child === id2) ||
+                   (link.parent === id2 && link.child === id1)) {
+                    links.splice(i, 1);
+                    break;
+                }
+            }
+
+            if (links.length === 0) delete this.lazyLinks[id1];
+        }
     },
 
     /**

--- a/lib/arch.js
+++ b/lib/arch.js
@@ -19,6 +19,8 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
         this.nodes = {};
         this.parents = {};
         this.children = {};
+        this.lazyParents = {};
+        this.lazyChildren = {};
         this.plans = {};
         this.locked = 0;
     },
@@ -135,7 +137,35 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
         parents && this.link([id], parents);
         children && this.link(children, [id]);
 
+        this.applyLazyLinks(node);
+
         return this;
+    },
+
+    applyLazyLinks: function(node) {
+        var id = U.getNodeId(node);
+
+        if (this.lazyChildren[id]) {
+            var parents = this.lazyChildren[id];
+
+            parents.forEach(function(p) {
+                if (this.hasNode(U.getNodeId(p.parent))) {
+                    this.link(p.child, p.parent);
+                    p.ref++;
+                }
+            }, this);
+        }
+
+        if (this.lazyParents[id]) {
+            var children = this.lazyParents[id];
+
+            children.forEach(function(c) {
+                if (this.hasNode(U.getNodeId(c.child))) {
+                    this.link(c.child, c.parent);
+                    c.ref++;
+                }
+            }, this);
+        }
     },
 
     /**
@@ -274,8 +304,41 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
      * @param {String[]|String} children Children nodes IDs.
      * @return {Arch}
      */
-    addChildren: function(id, children) {
-        return this.link(children, U.getNodeId(id));
+    addChildren: function(id, children, lazy) {
+        var parent = U.getNodeId(id);
+        children = U.toArray(children);
+
+        if (lazy) {
+            var childrenList = this.lazyParents[parent] = this.lazyParents[parent] || [];
+
+            children.forEach(function(c) {
+                var link = {
+                        parent: parent,
+                        child: U.getNodeId(c),
+                        ref: 0
+                    };
+
+
+                if (!this._lazyLinkExist(parent, link.child)) {
+                    childrenList.push(link);
+                    (this.lazyChildren[link.child] = this.lazyChildren[link.child] || []).push(link);
+                }
+            }, this);
+
+        }
+        return this.link(children, parent, lazy);
+    },
+
+    _lazyLinkExist: function(parent, child) {
+        var children = this.lazyParents[parent];
+
+        if (!children) return false;
+
+        for(var i = 0; i < children.length; i++) {
+            if (children[i].child === child) return true;
+        }
+
+        return false;
     },
 
     /**
@@ -285,8 +348,28 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
      * @param {String[]|String} parents Parents nodes IDs.
      * @return {Arch}
      */
-    addParents: function(id, parents) {
-        return this.link(U.getNodeId(id), parents);
+    addParents: function(id, parents, lazy) {
+        var child = U.getNodeId(id);
+        parents = U.toArray(parents);
+
+        if (lazy) {
+            var parentsList = this.lazyChildren[child] = this.lazyChildren[child] || [];
+
+            parents.forEach(function(p) {
+                var link = {
+                    parent: U.getNodeId(p),
+                    child: child,
+                    ref: 0
+                };
+
+                if (!this._lazyLinkExist(link.parent, child)) {
+                    parentsList.push(link);
+                    (this.lazyParents[link.parent] = this.lazyParents[link.parent] || []).push(link);
+                }
+            }, this);
+
+        }
+        return this.link(child, parents, lazy);
     },
 
     /**
@@ -296,15 +379,15 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
      * @param {String[]|String} parents IDs of parent nodes.
      * @returns {Arch} Chainable API.
      */
-    link: function(children, parents) {
+    link: function(children, parents, lazy) {
         children = U.toArray(children);
         parents = U.toArray(parents);
 
-        ASSERTS.hasIds(children, this);
-        ASSERTS.hasIds(parents, this);
+        !lazy && ASSERTS.hasIds(children, this);
+        !lazy && ASSERTS.hasIds(parents, this);
 
         children.forEach(function(child) {
-            this._link(child, parents);
+            this._link(child, parents, lazy);
         }, this);
 
         return this;
@@ -316,8 +399,10 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
      * @param {String} child Child node ID.
      * @param {Array} parents Parent nodes IDs.
      */
-    _link: function(child, parents) {
+    _link: function(child, parents, lazy) {
         child = U.getNodeId(child);
+
+        if (lazy && !this.hasNode(child)) return;
 
         var _parents = this.parents[child],
             children;
@@ -326,6 +411,8 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
             parent = U.getNodeId(parent);
 
             if (this.hasParents(child, parent)) return;
+
+            if (lazy && !this.hasNode(parent)) return;
 
             children = this.children[parent] || (this.children[parent] = []);
 

--- a/lib/arch.js
+++ b/lib/arch.js
@@ -213,6 +213,8 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
 
         U.removeNode(this.children, this.parents, id);
 
+        this.unlinkLazy(id);
+
         delete this.nodes[id];
 
         for (var k in this.plans) {
@@ -436,16 +438,26 @@ module.exports = INHERIT(/** @lends Arch.prototype */ {
         return this;
     },
 
+    /**
+     * Removes lazy links.
+     * @param {String} id1 First Node ID to unlink.
+     * @param {String} [id2] Second Node ID to unlink. If not specified all links where id1 is involved will be removed.
+     */
     unlinkLazy: function(id1, id2) {
         var links = this.lazyLinks[id1];
         if (links) {
             for(var i = links.length - 1; i >= 0; i--) {
                 var link = links[i];
 
-                if ((link.parent === id1 && link.child === id2) ||
-                   (link.parent === id2 && link.child === id1)) {
-                    links.splice(i, 1);
-                    break;
+                if (id2) {
+                    if ((link.parent === id1 && link.child === id2) ||
+                       (link.parent === id2 && link.child === id1)) {
+                        links.splice(i, 1);
+                        break;
+                    }
+                } else {
+                    this.unlinkLazy(link.parent, link.child);
+                    this.unlinkLazy(link.child, link.parent);
                 }
             }
 

--- a/lib/plan.js
+++ b/lib/plan.js
@@ -259,13 +259,19 @@ module.exports = INHERIT(EventEmitter, /** @lends Plan.prototype */ {
         }
     },
 
+    /**
+     * Returns true if specified node has lazy links with children which were not established as real yet false otherwise
+     * @param id
+     * @return {Boolean}
+     */
     hasLazyLinks: function(id) {
-        var children = this.arch.lazyParents[id];
+        var links = this.arch.lazyLinks[id];
 
-        if (!children) return false;
+        if (!links) return false;
 
-        for(var i = 0; i < children.length; i++) {
-            if (!U.hasLink(id, this.arch, 'children', children[i].child)) return true;
+        for(var i = 0; i < links.length; i++) {
+            var link = links[i];
+            if (link.parent === id && !U.hasLink(id, this.arch, 'children', link.child)) return true;
         }
 
         return false;

--- a/lib/plan.js
+++ b/lib/plan.js
@@ -259,7 +259,7 @@ module.exports = INHERIT(EventEmitter, /** @lends Plan.prototype */ {
      * @param {Object} wasHere Guardian to protect from loops.
      */
     _collectLeaves: function(id, leaves, wasHere) {
-        if (!wasHere[id] && !this.isJobAlreadyDone(id)) {
+        if (!wasHere[id] && !this.isJobAlreadyDone(id) && !this.hasLazyLinks(id)) {
 
             wasHere[id] = 1;
 
@@ -273,6 +273,18 @@ module.exports = INHERIT(EventEmitter, /** @lends Plan.prototype */ {
                 }
             }
         }
+    },
+
+    hasLazyLinks: function(id) {
+        var children = this.arch.lazyParents[id];
+
+        if (!children) return false;
+
+        for(var i = 0; i < children.length; i++) {
+            if (!U.hasLink(id, this.arch, 'children', children[i].child)) return true;
+        }
+
+        return false;
     },
 
     /**
@@ -536,7 +548,8 @@ module.exports = INHERIT(EventEmitter, /** @lends Plan.prototype */ {
 
         if (!this.isJobAlreadyDone(id) &&
             !this.isActiveJob(id) &&
-            this.jobs.indexOf(id) === -1) this.jobs.push(id);
+            this.jobs.indexOf(id) === -1 &&
+            !this.hasLazyLinks(id)) this.jobs.push(id);
 
         return this;
     },

--- a/test/arch-test.js
+++ b/test/arch-test.js
@@ -293,7 +293,7 @@ describe('Node lazy links', function() {
                 ref: 0
             };
 
-        arch.link('X', 'E', true);
+        arch.addParents('X', 'E', true);
 
         ASSERT.deepEqual(arch.children, c);
         ASSERT.deepEqual(arch.parents, p);
@@ -306,16 +306,34 @@ describe('Node lazy links', function() {
     });
 
     it('lazy link becomes real when both linking nodes become available in arch', function() {
-        arch.link('E', 'X', true);
+        arch.addParents('E', 'X', true);
         arch.addNode(createNode('X'));
 
         ASSERT(arch.hasChildren('X', 'E'));
     });
 
     it('unlink() removes lazy link', function() {
-        arch.link('E', 'X', true);
+        arch.addParents('E', 'X', true);
         arch.addNode(createNode('X'));
         arch.unlink('E', 'X');
+
+        ASSERT.deepEqual(arch.lazyLinks, {});
+    });
+
+    it('removeNode() removes lazy link when child is removed', function() {
+        arch.addParents('E', 'X', true);
+        arch.addNode(createNode('X'));
+
+        arch.removeNode('E');
+
+        ASSERT.deepEqual(arch.lazyLinks, {});
+    });
+
+    it('removeNode() removes lazy link when parent is removed', function() {
+        arch.addParents('E', 'X', true);
+        arch.addNode(createNode('X'));
+
+        arch.removeNode('X');
 
         ASSERT.deepEqual(arch.lazyLinks, {});
     });

--- a/test/arch-test.js
+++ b/test/arch-test.js
@@ -277,6 +277,9 @@ describe('Node link', function() {
 });
 
 describe('Node lazy links', function() {
+
+    var arch;
+
     beforeEach(function() {
         arch = getArch2();
     });
@@ -316,6 +319,7 @@ describe('Node lazy links', function() {
 
         ASSERT.deepEqual(arch.lazyLinks, {});
     });
+
 });
 
 describe('Node unlink', function() {

--- a/test/arch-test.js
+++ b/test/arch-test.js
@@ -2,6 +2,8 @@ var APW = require(process.env.COVER? '../lib-cov/apw' : '../lib/apw'),
     ASSERT = require('assert'),
     COMMON = require('./common'),
 
+    extend = require('node.extend'),
+
     getSimpleArch = COMMON.getSimpleArch,
     getEmptyArch = COMMON.getEmptyArch,
     createNode = COMMON.createNode,
@@ -239,6 +241,48 @@ describe('Node link', function() {
         
         ASSERT.equal(parents.length, 1);
         ASSERT.equal(parents[0], 'A');
+    });
+});
+
+describe('Node lazy links', function() {
+    beforeEach(function() {
+        arch = getArch2();
+    });
+
+    it('link() E -> nonexistent creates lazy link', function() {
+        var c = extend({}, arch.children),
+            p = extend({}, arch.parents),
+            link = {
+                parent: 'X',
+                child: 'E',
+                ref: 0
+            };
+
+        arch.link('E', 'X', true);
+
+        ASSERT.deepEqual(arch.children, c);
+        ASSERT.deepEqual(arch.parents, p);
+        ASSERT.deepEqual(arch.lazyLinks,
+            {
+                E: [link],
+                X: [link]
+            }
+        );
+    });
+
+    it('lazy link becomes real when both linking nodes become available in arch', function() {
+        arch.link('E', 'X', true);
+        arch.addNode(createNode('X'));
+
+        ASSERT(arch.hasChildren('X', 'E'));
+    });
+
+    it('unlink() removes lazy link', function() {
+        arch.link('E', 'X', true);
+        arch.addNode(createNode('X'));
+        arch.unlink('E', 'X');
+
+        ASSERT.deepEqual(arch.lazyLinks, {});
     });
 });
 

--- a/test/arch-test.js
+++ b/test/arch-test.js
@@ -253,12 +253,12 @@ describe('Node lazy links', function() {
         var c = extend({}, arch.children),
             p = extend({}, arch.parents),
             link = {
-                parent: 'X',
-                child: 'E',
+                parent: 'E',
+                child: 'X',
                 ref: 0
             };
 
-        arch.link('E', 'X', true);
+        arch.link('X', 'E', true);
 
         ASSERT.deepEqual(arch.children, c);
         ASSERT.deepEqual(arch.parents, p);


### PR DESCRIPTION
Периодически возникает идея дать возможность линковать несуществующие ноды. В теории это должно позволить использовать что-то вроде "отложенного линкования" — одна задача создаёт структуру линок на будущее, другая задача заполняет "мясом".

Технически всё это вполне несложно реализовать, но пока:
1. на практике нужды в этом ни разу не возникло,
2. даже в теории не возникло убедительных примеров нужды в такой фиче при невозможности / неудобстве решения той же проблемы имеющимися средствами.

Issue создан для того, чтобы в дальнейшем всё обсуждение велось в нём.
