### PR TITLE
Fail plan even if task promise rejected without reason

### DIFF
--- a/lib/workers.js
+++ b/lib/workers.js
@@ -213,7 +213,7 @@ module.exports = INHERIT(/** @lends Workers.prototype */ {
                 _this.next();
             },
             onError = function(err) {
-                _this.onJobFinished(job.id, err);
+                _this.onJobFinished(job.id, true, err);
             };
 
         this.activeWorkers++;
@@ -228,10 +228,11 @@ module.exports = INHERIT(/** @lends Workers.prototype */ {
      * Finish job processing, fire up listeners.
      *
      * @param {String} id Job ID.
-     * @param {Object} err Error, if any.
+     * @param {Boolean} fail True, if job failed.
+     * @param {Object} [err] Optional reason of failure.
      * @returns {Workers} Chainable API.
      */
-    onJobFinished: function(id, err) {
+    onJobFinished: function(id, fail, err) {
         var listeners = this.jobPlanFinishListeners[id] || {},
             plan, defer;
 
@@ -242,20 +243,20 @@ module.exports = INHERIT(/** @lends Workers.prototype */ {
 
             this.removeJobFinishListener(id, planId);
 
-            err? plan.onJobFail(id) : plan.onJobDone(id);
+            fail? plan.onJobFail(id) : plan.onJobDone(id);
 
-            if (err || plan.allDone()) this.terminatePlan(planId, err);
+            if (fail || plan.allDone()) this.terminatePlan(planId, fail, err);
         }
 
         return this;
     },
 
-    terminatePlan: function(planId, err) {
+    terminatePlan: function(planId, fail, err) {
         this.removePlan(planId);
         this.removePlanFinishListener(planId);
 
         var defer = this.getDefer(planId, true);
-        err? defer.reject(err) : defer.resolve();
+        fail? defer.reject(err) : defer.resolve();
     },
 
     /**


### PR DESCRIPTION
If node's `run` method returns rejected promise with no or falsy parameters (i.e. `Q.reject` or `Q.reject('')`) error was not handled correctly and plan didn't fail. This patches fixes it.

@arikon @scf2k 
